### PR TITLE
ignore .DS_Store files that Finder on the Mac drops everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .classpath
 .settings
 .project


### PR DESCRIPTION
Finder on the Mac creates .DS_Store files everywhere. This will help out anyone developing ratpack on a mac as these files will no longer show up in git status.
