### PR TITLE
Serving of static files/NPE on favicon when missing

### DIFF
--- a/src/main/groovy/com/bleedingwolf/ratpack/RatpackApp.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/RatpackApp.groovy
@@ -40,7 +40,7 @@ class RatpackApp {
     }
     
     Closure getHandler(method, subject) {
-        return handlers[method.toUpperCase()].route(subject)
+        return handlers[method.toUpperCase()]?.route(subject)
     }
     
     def get = { path, handler ->

--- a/src/main/groovy/com/bleedingwolf/ratpack/RatpackServlet.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/RatpackServlet.groovy
@@ -107,10 +107,10 @@ class RatpackServlet extends HttpServlet {
     
     protected URL staticFileFrom(path) {
         def publicDir = app.config.public
-        def fullPath = [publicDir, url].join(File.separator)
+        def fullPath = [publicDir, path].join(File.separator)
         def file = new File(fullPath)
 
-        if(file.exists()) return file
+        if(file.exists()) return file.toURI().toURL()
 
         try {
             return Thread.currentThread().contextClassLoader.getResource([publicDir, path].join('/'))


### PR DESCRIPTION
This commit fixes serving of static files when the public config setting is set.

Removed an undeclared variable from staticFileFrom and forced cast from File->URI->URL.

b98fdab fixes a bug where a NPE is thrown on favicons if they aren't in the routing table. Added a safe navigation operator.
