### PR TITLE
Fix ClassNotFoundException: com.bleedingwolf.ratpack.RatpackRunner

### DIFF
--- a/src/main/binaries/ratpack
+++ b/src/main/binaries/ratpack
@@ -1,8 +1,13 @@
 #!/usr/bin/env groovy
 def loader = this.class.classLoader.rootLoader
-def jardir = new File(new File(getClass().protectionDomain.codeSource.location.path).parentFile.parentFile,'lib')
-def jars   = jardir.listFiles().findAll { it.name.endsWith('.jar') } 
-jars.each { loader.addURL(it.toURI().toURL()) }
+def commandPath = getClass().protectionDomain.codeSource.location.path
+def buildPath = new File(commandPath).parentFile.parentFile.parentFile
+def jardir = new File("${buildPath}/ratpack",'lib')
+
+def jars      = jardir.listFiles().findAll { it.name.endsWith('.jar') } 
+def classes = [new File("${buildPath}/classes/main").toURI().toURL() ]
+
+[classes,jars]*.each { loader.addURL(it.toURI().toURL()) }
 
 def scriptFile = new File(args[0])
 


### PR DESCRIPTION
Add build/classes to ratpack script for so that RatpackRunner is accessible. The other option was to add the build/libs/ratpack*jar to the path which should also work.

Original behavior:

<pre>
[master] ratpack: export PATH=$PATH:$HOME/ratpack/build/ratpack/bin
[master] ratpack: ratpack hello.groovy 
org.codehaus.groovy.tools.RootLoader@64578ceb
Caught: java.lang.ClassNotFoundException: com.bleedingwolf.ratpack.RatpackRunner
    at ratpack.run(ratpack:10)
</pre>
