### PR TITLE
SLF4J and newer jUnit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20090211'
     compile(group: 'org.mortbay.jetty', name: 'jetty', version: '6.1.26') { exclude module: 'servlet-api' }
     compile(group: 'org.mortbay.jetty', name: 'jetty-util', version: '6.1.26') { exclude module: 'servlet-api' }
+	compile 'org.slf4j:slf4j-api:1.6.3'
     
     testCompile group: 'junit', name: 'junit', version: '4.10'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compile 'org.slf4j:slf4j-api:1.6.3'
     
     testCompile group: 'junit', name: 'junit', version: '4.10'
+	testRuntime 'org.slf4j:slf4j-simple:1.6.3'
 }
 
 task copyToLib(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -10,14 +10,14 @@ repositories {
 }
 
 dependencies {
-    groovy group: 'org.codehaus.groovy', name: 'groovy', version: '1.7.9'
+    groovy group: 'org.codehaus.groovy', name: 'groovy', version: '1.8.3'
     
     compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
     compile group: 'org.json', name: 'json', version: '20090211'
     compile(group: 'org.mortbay.jetty', name: 'jetty', version: '6.1.26') { exclude module: 'servlet-api' }
     compile(group: 'org.mortbay.jetty', name: 'jetty-util', version: '6.1.26') { exclude module: 'servlet-api' }
     
-    testCompile group: 'junit', name: 'junit', version: '4.8.2'
+    testCompile group: 'junit', name: 'junit', version: '4.10'
 }
 
 task copyToLib(type: Copy) {

--- a/src/main/binaries/ratpack
+++ b/src/main/binaries/ratpack
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 def loader = this.class.classLoader.rootLoader
+@Grapes([
+	@Grab('org.slf4j:slf4j-simple:1.6.3'),
+	@GrabConfig(systemClassLoader=true)
+])
 def commandPath = getClass().protectionDomain.codeSource.location.path
 def buildPath = new File(commandPath).parentFile.parentFile.parentFile
 def jardir = new File("${buildPath}/ratpack",'lib')

--- a/src/main/groovy/com/bleedingwolf/ratpack/RatpackApp.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/RatpackApp.groovy
@@ -2,8 +2,11 @@ package com.bleedingwolf.ratpack
 
 import com.bleedingwolf.ratpack.routing.Route
 import com.bleedingwolf.ratpack.routing.RoutingTable
+import org.slf4j.LoggerFactory
 
 class RatpackApp {
+
+	final logger = LoggerFactory.getLogger(getClass())
 
     def handlers = [
         'GET': new RoutingTable(),

--- a/src/main/groovy/com/bleedingwolf/ratpack/RatpackRequestDelegate.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/RatpackRequestDelegate.groovy
@@ -1,5 +1,6 @@
 package com.bleedingwolf.ratpack
 import org.json.JSONObject
+import org.slf4j.LoggerFactory
 
 public class RatpackRequestDelegate {
 
@@ -12,6 +13,7 @@ public class RatpackRequestDelegate {
     def request = null
     def response = null
     def requestParamReader = new RatpackRequestParamReader()
+	final org.slf4j.Logger logger = LoggerFactory.getLogger(getClass())
 
     void setHeader(name, value) {
         response.setHeader(name.toString(), value.toString())

--- a/src/main/groovy/com/bleedingwolf/ratpack/RatpackServlet.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/RatpackServlet.groovy
@@ -8,9 +8,11 @@ import javax.servlet.http.HttpServletResponse
 import org.mortbay.jetty.Server
 import org.mortbay.jetty.servlet.Context
 import org.mortbay.jetty.servlet.ServletHolder
-
+import org.slf4j.LoggerFactory
 
 class RatpackServlet extends HttpServlet {
+	protected final org.slf4j.Logger logger = LoggerFactory.getLogger(getClass())
+
     def app = null
 	MimetypesFileTypeMap mimetypesFileTypeMap = new MimetypesFileTypeMap()
 
@@ -19,7 +21,7 @@ class RatpackServlet extends HttpServlet {
 	    	def appScriptName = getServletConfig().getInitParameter("app-script-filename")
 			  def fullScriptPath = getServletContext().getRealPath("WEB-INF/lib/${appScriptName}")
 
-	    	println "Loading app from script '${appScriptName}'"
+	    	logger.info('Loading app from script "{}"', appScriptName)
 			loadAppFromScript(fullScriptPath)
 		}
 		mimetypesFileTypeMap.addMimeTypes(this.class.getResourceAsStream('mime.types').text)
@@ -51,8 +53,7 @@ class RatpackServlet extends HttpServlet {
             }
             catch(RuntimeException ex) {
 
-                // FIXME: use log4j or similar
-                println "[ Error] Caught Exception: ${ex}"
+                logger.error('Handling {} {}', [ verb, path, ex] as Object[])
 
                 res.status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR
                 output = renderer.renderException(ex, req)
@@ -84,8 +85,7 @@ class RatpackServlet extends HttpServlet {
         stream.flush()
         stream.close()
 
-        // FIXME: use log4j or similar
-        println "[   ${res.status}] ${verb} ${path}"
+        logger.info("[   ${res.status}] ${verb} ${path}")
     }
 
     protected boolean staticFileExists(path) {
@@ -125,8 +125,7 @@ class RatpackServlet extends HttpServlet {
         def servlet = new RatpackServlet()
         servlet.app = theApp
 
-        println "Starting Ratpack app with config:"
-        println theApp.config
+        theApp.logger.info('Starting Ratpack app with config:\n{}', theApp.config)
 
         def server = new Server(theApp.config.port)
         def root = new Context(server, "/", Context.SESSIONS)


### PR DESCRIPTION
I updated the Gradle script to use 1.8.3 because it's what I use. It compiled fine, but you might want to keep using an older version. I also updated to jUnit 4.10, which shouldn't be a problem.

I also added SLF4J; the servlet now has a logger instead of using println. The App also has a logger, as does the request delegate, which is cool because now the scripts can use logger.info, logger.error, etc.
