### PR TITLE
request delegates not thread safe

### DIFF
--- a/src/main/groovy/com/bleedingwolf/ratpack/routing/RoutingTable.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/routing/RoutingTable.groovy
@@ -13,11 +13,13 @@ class RoutingTable {
     
     def route(subject) {
         def found = routeHandlers.find { null != it.route.match(subject) }
+        def newHandler = found.handler.clone()
+
         if (found) {
             def urlparams = found.route.match(subject)
             def foundHandler = { ->            
-                found.handler.delegate = delegate
-                found.handler()
+                newHandler.delegate = delegate
+                newHandler()
             }
             foundHandler.delegate = new RatpackRequestDelegate()
             foundHandler.delegate.urlparams = urlparams

--- a/src/main/groovy/com/bleedingwolf/ratpack/routing/RoutingTable.groovy
+++ b/src/main/groovy/com/bleedingwolf/ratpack/routing/RoutingTable.groovy
@@ -13,9 +13,9 @@ class RoutingTable {
     
     def route(subject) {
         def found = routeHandlers.find { null != it.route.match(subject) }
-        def newHandler = found.handler.clone()
-
+        
         if (found) {
+            def newHandler = found.handler.clone()
             def urlparams = found.route.match(subject)
             def foundHandler = { ->            
                 newHandler.delegate = delegate


### PR DESCRIPTION
The values 'params' and 'urlparams' etc from the request delegate are not thread safe.
If a second request comes into a request handler while the previous one is
still processing, the value of 'params' and 'urlparams' are replaced in the
namespace of the original request.

My fix is to clone the request handler closure before setting the delegate,
thus creating a localized namespace.

This will impart a small performance hit

To replicate the issue: 

```
get ('/testing/:value' ){

Thread.sleep(1000)

return "Value: ${urlparams.value}\n\n";

}
```

Then run 

curl "http://localhost:5000/testing/ONE" & curl "http://localhost:5000/testing/TWO"

Both requests will return the same value (either ONE or TWO, depending on the order the requests execute)
